### PR TITLE
Fix Broken Proofs Link

### DIFF
--- a/_posts/2017-08-17-sum_of_uniformly_random_numbers.md
+++ b/_posts/2017-08-17-sum_of_uniformly_random_numbers.md
@@ -9,7 +9,7 @@ libs: [mathjax]
     @@\newcommand{\nl}{\\}@@
 </div>
 
-_This post used to be hosted at [ammrat13/proofs](https://github.com/ammrat13/proofs),
+_This post used to be hosted on my [GitHub](https://github.com/ammrat13),
 but I felt it would fit better here. I found this fact online somewhere, and I
 wanted to try and prove it myself. The way I did so is far from elegant. In
 particular, I didn't see the connection between uniformly choosing then summing

--- a/_posts/2018-03-31-polynomial_over_geometric_series.md
+++ b/_posts/2018-03-31-polynomial_over_geometric_series.md
@@ -8,7 +8,7 @@ libs: [mathjax]
     @@\newcommand{\nl}{\\}@@
 </div>
 
-_This post used to be hosted at [ammrat13/proofs](https://github.com/ammrat13/proofs),
+_This post used to be hosted on my [GitHub](https://github.com/ammrat13),
 but I felt it would fit better here. I wrote this when we covered sequences and
 series in Calculus BC. I was interested in these particular series since they
 weren't covered in class, and I found them to be a good opportunity to practice

--- a/_posts/2018-06-10-reddit_problem.md
+++ b/_posts/2018-06-10-reddit_problem.md
@@ -7,7 +7,7 @@ libs: [mathjax]
     @@\newcommand{\nl}{\\}@@
 </div>
 
-_This post used to be hosted at [ammrat13/proofs](https://github.com/ammrat13/proofs),
+_This post used to be hosted on my [GitHub](https://github.com/ammrat13),
 but I felt it would fit better here. I was intrigued by this problem because it
 tied into what I learned in Calculus BC. Only now do I know I didn't have the
 techniques I needed to tackle this problem. I can't quite put my finger on why,


### PR DESCRIPTION
A while back I made my `proofs` repository private but didn't remove the links to it from my website. This PR does that.