### PR TITLE
Refactor Pagination and Related Posts

### DIFF
--- a/_data/post_listing.yml
+++ b/_data/post_listing.yml
@@ -1,0 +1,5 @@
+# Data parameterizing the `post_listing` page
+
+# How many pages to show on each side of the current page in the pagination bar
+# The total number of pages shown will be 2 * paginationBarDelta + 1
+paginationBarDelta: 1

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,17 +16,6 @@ libs: [postsel]
 {% endfor %}
 
 {% comment %}
-    Calculate the starting index. Account for very early posts by subtracting
-    more.
-{% endcomment %}
-{% assign numPosts = site.posts | size %}
-{% assign postNumSel = site.data.post_select.postNumSel %}
-{% assign halfNumSel = postNumSel | divided_by: 2 %}
-{% assign earlyPostCorr = halfNumSel | minus: numPosts | plus: postIdx | plus: 1 | at_least: 0 %}
-{% assign startIdx = postIdx | minus: halfNumSel | minus: earlyPostCorr | at_least: 0 %}
-
-
-{% comment %}
     Have a separate paragraph for the title due to spacing.
 {% endcomment %}
 <p>
@@ -39,7 +28,31 @@ libs: [postsel]
 </div>
 <hr/>
 
+{% comment %}
+    Calculate the starting index we should display posts from. We get the total
+    number of posts we need to display. We should display half on each side of this
+    post, biasing towards more recent posts if needed.
+
+    Remember, the maximum index is `numPosts - 1`, not `numPosts`, since we
+    will be skipping the current post. Also, low indicies are more recent posts.
+{% endcomment %}
+{% assign numPosts = site.posts | size %}
+{% assign numSel = site.data.post_select.postNumSel %}
+{% assign halfNumSel = numSel | divided_by: 2.0 | ceil %}
+{% assign startIdx = postIdx | minus: halfNumSel %}
+
+{% comment %}
+    If we're toward the old posts - toward the end of the array - we want to
+    backfill with more recent posts.
+
+    Make sure the index doesn't go negative. If it does, we'll start taking from
+    the opposite end of the array, which isn't what we want. Instead, we want to
+    take the most recent posts.
+{% endcomment %}
+{% assign startIdxMax = numPosts | minus: numSel | minus: 1 %}
+{% assign startIdx = startIdx | at_most: startIdxMax | at_least: 0 %}
+
 <p>
     <h2>Related Posts</h2>
 </p>
-{% include post_select.html start=startIdx num=postNumSel skipId=page.id %}
+{% include post_select.html start=startIdx num=numSel skipId=page.id %}

--- a/post_listing/index.html
+++ b/post_listing/index.html
@@ -42,16 +42,16 @@ libs: [postsel]
                 The templates for pages get a bit nasty. So, compute them once
                 and store them in variables
             {% endcomment %}
-            {% assign first_page_href = site.paginate_path | replace: ':num', '' | relative_url %}
-            {% assign next_page_href = paginator.next_page_path | relative_url %}
-            {% assign prev_page_href = paginator.previous_page_path | relative_url %}
-            {% assign last_page_href = site.paginate_path | replace: ':num', paginator.total_pages | relative_url %}
+            {% assign firstPageHref = site.paginate_path | replace: ':num', '' | relative_url %}
+            {% assign nextPageHref = paginator.next_page_path | relative_url %}
+            {% assign prevPageHref = paginator.previous_page_path | relative_url %}
+            {% assign lastPageHref = site.paginate_path | replace: ':num', paginator.total_pages | relative_url %}
 
             <li class="page-item {% if paginator.page == 1 %} disabled {% endif %}">
-                <a class="page-link" href="{{ first_page_href }}">&laquo;</a>
+                <a class="page-link" href="{{ firstPageHref }}">&laquo;</a>
             </li>
             <li class="page-item {% unless paginator.previous_page %} disabled {% endunless %}">
-                <a class="page-link" href="{{ prev_page_href }}">&lsaquo;</a>
+                <a class="page-link" href="{{ prevPageHref }}">&lsaquo;</a>
             </li>
 
             {% comment %}
@@ -60,32 +60,32 @@ libs: [postsel]
             {% endcomment %}
             {% assign delta = site.data.post_listing.paginationBarDelta %}
             {% assign window = delta | times: 2 | plus: 1 %}
-            {% assign start_page = paginator.page | minus: delta | at_least: 1 %}
-            {% assign end_page = paginator.page | plus: delta | at_most: paginator.total_pages %}
-            {% assign start_page = end_page | minus: window | at_least: 1 %}
-            {% assign end_page = start_page | plus: window | at_most: paginator.total_pages %}
+            {% assign startPage = paginator.page | minus: delta | at_least: 1 %}
+            {% assign endPage = paginator.page | plus: delta | at_most: paginator.total_pages %}
+            {% assign startPage = endPage | minus: window | at_least: 1 %}
+            {% assign endPage = startPage | plus: window | at_most: paginator.total_pages %}
 
-            {% for page in (start_page..end_page) %}
+            {% for page in (startPage..endPage) %}
                 {% comment %}
                     Compute the path of this page. The pagination extension
                     handles the first page specially (for some reason).
                 {% endcomment %}
                 {% if page == 1 %}
-                    {% assign page_href = first_page_href %}
+                    {% assign pageHref = firstPageHref %}
                 {% else %}
-                    {% assign page_href = site.paginate_path | replace: ':num', page | relative_url %}
+                    {% assign pageHref = site.paginate_path | replace: ':num', page | relative_url %}
                 {% endif %}
 
                 <li class="page-item {% if page == paginator.page %} active {% endif %}">
-                    <a class="page-link" href="{{ page_href }}">{{ page }}</a>
+                    <a class="page-link" href="{{ pageHref }}">{{ page }}</a>
                 </li>
             {% endfor %}
 
             <li class="page-item {% unless paginator.next_page %} disabled {% endunless %}">
-                <a class="page-link" href="{{ next_page_href }}">&rsaquo;</a>
+                <a class="page-link" href="{{ nextPageHref }}">&rsaquo;</a>
             </li>
             <li class="page-item {% if paginator.page == paginator.total_pages %} disabled {% endif %}">
-                <a class="page-link" href="{{ last_page_href }}">&raquo;</a>
+                <a class="page-link" href="{{ lastPageHref }}">&raquo;</a>
             </li>
         </ul>
     </nav>

--- a/post_listing/index.html
+++ b/post_listing/index.html
@@ -55,15 +55,15 @@ libs: [postsel]
             </li>
 
             {% comment %}
-                We want to show this page +/- DELTA pages. Always try to fill
-                with extra pages on the left and right though.
+                We want to show this page +/- paginationBarDelta pages. Always
+                try to fill with extra pages on the left and right though.
             {% endcomment %}
-            {% assign DELTA = 1 %}
-            {% assign WINDOW = DELTA | times: 2 | plus: 1 %}
-            {% assign start_page = paginator.page | minus: DELTA | at_least: 1 %}
-            {% assign end_page = paginator.page | plus: DELTA | at_most: paginator.total_pages %}
-            {% assign start_page = end_page | minus: WINDOW | at_least: 1 %}
-            {% assign end_page = start_page | plus: WINDOW | at_most: paginator.total_pages %}
+            {% assign delta = site.data.post_listing.paginationBarDelta %}
+            {% assign window = delta | times: 2 | plus: 1 %}
+            {% assign start_page = paginator.page | minus: delta | at_least: 1 %}
+            {% assign end_page = paginator.page | plus: delta | at_most: paginator.total_pages %}
+            {% assign start_page = end_page | minus: window | at_least: 1 %}
+            {% assign end_page = start_page | plus: window | at_most: paginator.total_pages %}
 
             {% for page in (start_page..end_page) %}
                 {% comment %}


### PR DESCRIPTION
Now, we can parameterize how many pages to display in the pagination bar. This pull request also fixes an issue where old posts wouldn't display enough related posts.