### PR TITLE
Style Copyright Link

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -115,7 +115,7 @@ libs: []
 
         <footer id="footer">
             <hr/>
-            <a href="/LICENSE.md">Copyright &copy;</a> 2025 Ammar Ratnani<br/>
+            <a href="/LICENSE.md" class="text-body">Copyright &copy; 2025 Ammar Ratnani</a><br/>
             <abbr title="Software Package Data Exchange">SPDX</abbr> License Identifier: CC-BY-4.0 AND MIT
         </footer>
     </body>


### PR DESCRIPTION
Now, the entire copyright line is clickable. It's also styled as normal text, so it's more subtle.