### PR TITLE
Style Copyright Text

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -125,8 +125,10 @@ libs: []
 
         <footer id="footer">
             <hr/>
-            <a href="/LICENSE.md" class="text-body">Copyright &copy; 2025 Ammar Ratnani</a><br/>
-            <abbr title="Software Package Data Exchange">SPDX</abbr> License Identifier: CC-BY-4.0 AND MIT
+            <a href="/LICENSE.md" class="text-muted">
+                Copyright &copy; 2025 Ammar Ratnani<br/>
+                SPDX License Identifier: CC-BY-4.0 AND MIT
+            </a>
         </footer>
     </body>
 


### PR DESCRIPTION
This commit makes the text gray instead of black, to make it more subtle. It also makes the whole text link to the license, instead of just the copyright line. Finally, it removes the abbreviation for SPDX --- I don't think it's needed for understanding.