### PR TITLE
Cursor Rules and Kramdown Abbreviations

### DIFF
--- a/.cursor/rules/dont-touch-posts.mdc
+++ b/.cursor/rules/dont-touch-posts.mdc
@@ -1,0 +1,14 @@
+---
+globs: _posts/*.md
+alwaysApply: false
+---
+Never directly edit the bodies of the files in the `_posts/` subdirectory.
+Instead, propose changes to the body of a post to the user in natural language.
+
+The contents of the user's blog should ultimately come from the user themselves.
+Hence, you may read the posts. You may critique them, or you may brainstorm
+ideas for the posts. But the words in the posts must come from the user.
+
+You may only edit the front matter of posts --- the YAML between the first two
+`---`s. The front matter is not the primary content of the blog, since it just
+configures libraries and appearance.

--- a/_about/me.md
+++ b/_about/me.md
@@ -8,8 +8,7 @@ title: About Me
     accessible.
 {% endcomment %}
 
-Hey! I'm
-<abbr title="Ammar Ratnani (he/him)">Ammar</abbr>
+Hey! I'm Ammar
 <a href="/assets/public.asc" aria-label="OpenPGP Public Key" class="text-body pgpLink"><i class="fa-solid fa-key" aria-hidden="true"></i></a>.
 Right now, I'm a software engineer working on [GeForce NOW][1], but my interests
 are ... varied. I've done embedded systems, digital design, compiler work, and
@@ -19,6 +18,8 @@ I've done some side projects, and I figured my work wasn't doing much just
 sitting around. So, I started this site. Feel free to look through what I've
 done. You might also want to check out my [GitHub][2]. Don't be afraid to reach
 out to me either. Shoot me an email, and I'll get back to you. (Eventually.)
+
+*[Ammar]: Ammar Ratnani (he/him)
 
 [1]: https://www.nvidia.com/en-us/geforce-now/ "NVIDIA: GeForce NOW"
 [2]: https://github.com/ammrat13/ "Github: ammrat13 (Ammar Ratnani)"


### PR DESCRIPTION
This pull request:
 * Uses Kramdown's abbreviation functionality to avoid an explicit `<abbr>` tag in the about section
 * Adds a Cursor rule not to touch the post bodies