### PR TITLE
Accessible headings and RSS feed

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,7 +1,7 @@
 ---
 layout: base
 stylesheet: post
-libs: [postsel]
+libs: [postsel, fa]
 ---
 
 {% comment %}
@@ -80,6 +80,9 @@ libs: [postsel]
 {% assign startIdx = startIdx | at_most: startIdxMax | at_least: 0 %}
 
 <p>
-    <h2>Related Posts</h2>
+    <h1>
+        <a href="/feed.xml" aria-label="RSS Feed" class="text-body rssLink"><i class="fa-solid fa-square-rss" aria-hidden="true"></i></a>
+        Related Posts
+    </h1>
 </p>
 {% include post_select.html start=startIdx num=numSel skipId=page.id %}

--- a/_posts/2018-06-10-reddit_problem.md
+++ b/_posts/2018-06-10-reddit_problem.md
@@ -16,14 +16,14 @@ but my proof seems wrong to me. For instance, I prove an integral converges by
 bounding it between two values, which I can't immediately say is true. I'm not
 proud of this work, but I thought I'd put it here for completeness._
 
-### The Problem
+## The Problem
 Reddit user `u/Poliorcetyks` posed the following question on `r/learnmath` in
 his post titled *Integrals with parameter, problem proving continuity*. Given a
 function
 %% f(x) = \int_0^1 \frac{\ln\left(\frac{1}{t}\right)^x}{t+1}\,dt, %%
 find the domain of @@f@@ and show that it is continuous on its domain.
 
-### Domain
+## Domain
 We begin by bounding @@f@@ between two other functions. Note that for all @@0
 \leq t \leq 1@@ that
 %% \frac{1}{2} \leq \frac{1}{t+1} \leq 1 %%
@@ -108,7 +108,7 @@ equal to @@-1@@ are in the domain of @@\Pi@@, and are thus not in the domain of
 In summary, we conclude that the domain of @@\Pi@@, and thus of @@f@@, is the
 set of all real numbers strictly greater than @@-1@@.
 
-### Continuity
+## Continuity
 To show that @@f@@ is continuous on its domain, we must show that @@\lim_{h \to
 0} f(x+h) = f(x)@@. To show that, we first note two facts. First, that
 %% f(x) = \lim_{a \to 0^+} \int_a^{1-a} \frac{\ln\left(\frac{1}{t}\right)^x}{t+1}\,dt, %%

--- a/_posts/2020-08-08-logistic_parameters_virus.md
+++ b/_posts/2020-08-08-logistic_parameters_virus.md
@@ -153,6 +153,6 @@ do compute a population-wide average for
 even though individual @@R_0@@s can vary wildly. It seems this simple logistic
 model is more versatile than I give it credit for.
 
-### Resources
+## Resources
 * [Code for this post](https://github.com/ammrat13/ammrat13.github.io/tree/main/assets/2020/08/08/simulation)
 * [Simulator for invent**summer**](https://github.com/ammrat13/inventsummer-2020/tree/master/covidsim)

--- a/_posts/2020-09-07-random_movement_equilibrium.md
+++ b/_posts/2020-09-07-random_movement_equilibrium.md
@@ -163,5 +163,5 @@ instance, you might notice that the Markov chain seems to overestimate the
 number of people around the edges. Why is that? I invite you all to take a look
 at the code and see what you can find.
 
-### Resources
+## Resources
 * [Code for this post](https://github.com/ammrat13/ammrat13.github.io/tree/main/assets/2020/09/07/simulation)

--- a/_posts/2020-12-31-edge_coloring_complete_graphs_of_even_order.md
+++ b/_posts/2020-12-31-edge_coloring_complete_graphs_of_even_order.md
@@ -328,7 +328,7 @@ the realm of a student's understanding. That's why I do them.
 
 ---
 
-### Resources
+## Resources
 * [Code to check my algorithm](https://github.com/ammrat13/ammrat13.github.io/blob/main/assets/2020/12/31/code/even_complete_edge_coloring.py)
 * [Code to display the results](https://github.com/ammrat13/ammrat13.github.io/blob/main/assets/2020/12/31/code/display_even_complete_edge_coloring.sage)
 * [Code to ensure no good paths](https://github.com/ammrat13/ammrat13.github.io/blob/main/assets/2020/12/31/code/has_good_ordering.py)

--- a/_posts/2021-01-15-csaw_2020_finals_eccentric.md
+++ b/_posts/2021-01-15-csaw_2020_finals_eccentric.md
@@ -563,7 +563,7 @@ flag{wh0_sa1d_e11ipt1c_curv3z_r_s3cur3??}
 
 ---
 
-### Resources
+## Resources
 
 This post may or may not have helped you understand Smart's attack. Ultimately,
 there's no substitute for practice --- for struggling through the material

--- a/_posts/2022-06-13-defcon_quals_2022_sameold.md
+++ b/_posts/2022-06-13-defcon_quals_2022_sameold.md
@@ -46,9 +46,9 @@ Redundancy Check (CRC). It is guaranteed to find a solution, and it does so much
 faster than the straightforward but exponential method.
 
 
-#### Introduction
+## Introduction
 
-##### How CRCs Work
+### How CRCs Work
 
 First, it's necessary to understand some of the math underlying CRCs.
 Ultimately, the goal of any checksum is to take in some data and derive from it
@@ -111,7 +111,7 @@ to the message. In general, if the table method is seeded with @@p@@, it XORs
 that with the first 32 bits of the input, or it equivalently prepends @@p \cdot
 x^{-32}@@.
 
-##### The Choice of π
+### The Choice of π
 
 It's worth noting some properties of CRC-32's choice of @@\pi@@. That polynomial
 is *irreducible* over @@\FF_2@@, meaning it can't be factored any further
@@ -177,7 +177,7 @@ This is not the only proof of this theorem. Another, also from
 field would have zero divisors otherwise.
 
 
-#### Approach
+## Approach
 
 With all the introductory material out of the way, we can start tackling the
 actual problem. As a reminder, we want to find a string that starts with a
@@ -223,14 +223,14 @@ This system can be easily solved, though not necessarily uniquely, as long as
 @@\matr{V}@@'s columns span @@\FF_{2^{32}}@@.
 
 
-#### Failure Resistance
+## Failure Resistance
 
 So when does that fail? Clearly, when @@\ell@@ is too small, there aren't enough
 vectors for a baisis and thus too few for a spanning set. The least you can
 possibly get away with is @@\ell = \dim\FF_{2^{32}} = 32@@. In some cases,
 that's also sufficient.
 
-##### On "2<sup>*w*</sup>-Periodic" Bases
+### On "2<sup>*w*</sup>-Periodic" Bases
 
 Specifically, when the attacker can choose to substitute individual words
 independently of each other, assuming a word's length is a power of two @@2^w@@,
@@ -269,7 +269,7 @@ Apply the above theorem @@k@@ times. □
 The result we set out to prove is this corollary with @@p=2@@, @@k=w@@, and
 @@b_i = x^i@@.
 
-##### On *n* Consecutive Powers of Primitive Elements
+### On *n* Consecutive Powers of Primitive Elements
 
 The result in the previous section was agnostic to our choice of @@b_i@@.
 However, our basis is usually quite "nice". For example, in the last section, we
@@ -322,7 +322,7 @@ above theorem and the lemma before it. As for any @@n@@ consecutive powers, with
 multiplication with @@g^d@@. □
 
 
-#### Future Work
+## Future Work
 
 Characterizing powers of two and consecutive powers is relatively easy. However,
 real-world situations might not afford this structure. Attackers might only be
@@ -349,7 +349,7 @@ it's clearly very loose. Intuitively, we'd expect it to be close to
 tighter bound on the number of bytes needed.
 
 
-#### Worked Example
+## Worked Example
 
 Suppose I want to find a string that starts with `DC`, only contains the letters
 `G` and `T` after that, and whose CRC-32 is the same as the string `the`. I
@@ -406,12 +406,12 @@ which corresponds to the message `DCGGTTGTTTTTGTTTTGTGTTTTTTTTGGGTTG`. Remeber
 that @@\vect{\alpha}[0]@@ corresponds to the last character of the string.
 
 
-#### Resources
+## Resources
 
 * [Code implementing this solution][10]
 
 
-#### Appendix: Previous Results
+## Appendix: Previous Results
 
 This section lists facts I used to prove my main results.
 

--- a/assets/css/post.scss
+++ b/assets/css/post.scss
@@ -87,3 +87,8 @@ blockquote :last-child {
         margin-bottom: 0;
     }
 }
+
+/* Copy from `index.scss` */
+.rssLink:hover {
+    opacity: .7;
+}


### PR DESCRIPTION
Add RSS to the related posts section.

Also, make sure the headings don't skip levels. Now, the post itself and the related posts are `h1`s. Headings in the post should start at `h2`.