### PR TITLE
Fixup Broken Links After GitLab Migration

### DIFF
--- a/_posts/2017-08-17-sum_of_uniformly_random_numbers.md
+++ b/_posts/2017-08-17-sum_of_uniformly_random_numbers.md
@@ -12,12 +12,11 @@ libs_config:
             value: \text{C}
 ---
 
-_This post used to be hosted on my [GitHub](https://github.com/ammrat13),
-but I felt it would fit better here. I found this fact online somewhere, and I
-wanted to try and prove it myself. The way I did so is far from elegant. In
-particular, I didn't see the connection between uniformly choosing then summing
-real numbers and higher-dimensional right tetrahedra. Nonetheless, it works (I
-think) and I'm quite proud of it._
+_This post used to be hosted on my GitHub, but I felt it would fit better here.
+I found this fact online somewhere, and I wanted to try and prove it myself. The
+way I did so is far from elegant. In particular, I didn't see the connection
+between uniformly choosing then summing real numbers and higher-dimensional
+right tetrahedra. Nonetheless, it works (I think) and I'm quite proud of it._
 
 A rather famous question in probability goes as follows. Suppose you pick a real
 number @@X_1@@ uniformly at random on @@[0,1]@@, then pick another real number

--- a/_posts/2018-03-31-polynomial_over_geometric_series.md
+++ b/_posts/2018-03-31-polynomial_over_geometric_series.md
@@ -10,11 +10,10 @@ libs_config:
             value: \blacksquare
 ---
 
-_This post used to be hosted on my [GitHub](https://github.com/ammrat13),
-but I felt it would fit better here. I wrote this when we covered sequences and
-series in Calculus BC. I was interested in these particular series since they
-weren't covered in class, and I found them to be a good opportunity to practice
-the techniques I learned._
+_This post used to be hosted on my GitHub, but I felt it would fit better here.
+I wrote this when we covered sequences and series in Calculus BC. I was
+interested in these particular series since they weren't covered in class, and I
+found them to be a good opportunity to practice the techniques I learned._
 
 Consider the infinite sum
 %%S = \sum_{k=1}^\infty \frac{k^m}{n^k}.%%

--- a/_posts/2018-06-10-reddit_problem.md
+++ b/_posts/2018-06-10-reddit_problem.md
@@ -8,13 +8,13 @@ libs_config:
             value: \\
 ---
 
-_This post used to be hosted on my [GitHub](https://github.com/ammrat13),
-but I felt it would fit better here. I was intrigued by this problem because it
-tied into what I learned in Calculus BC. Only now do I know I didn't have the
-techniques I needed to tackle this problem. I can't quite put my finger on why,
-but my proof seems wrong to me. For instance, I prove an integral converges by
-bounding it between two values, which I can't immediately say is true. I'm not
-proud of this work, but I thought I'd put it here for completeness._
+_This post used to be hosted on my GitHub, but I felt it would fit better here.
+I was intrigued by this problem because it tied into what I learned in Calculus
+BC. Only now do I know I didn't have the techniques I needed to tackle this
+problem. I can't quite put my finger on why, but my proof seems wrong to me. For
+instance, I prove an integral converges by bounding it between two values, which
+I can't immediately say is true. I'm not proud of this work, but I thought I'd
+put it here for completeness._
 
 ## The Problem
 Reddit user `u/Poliorcetyks` posed the following question on `r/learnmath` in

--- a/_posts/2020-08-08-logistic_parameters_virus.md
+++ b/_posts/2020-08-08-logistic_parameters_virus.md
@@ -155,4 +155,4 @@ model is more versatile than I give it credit for.
 
 ## Resources
 * [Code for this post](https://github.com/ammrat13/ammrat13.github.io/tree/main/assets/2020/08/08/simulation)
-* [Simulator for invent**summer**](https://github.com/ammrat13/inventsummer-2020/tree/master/covidsim)
+* [Simulator for invent**summer**](https://gitlab.com/ammrat13/inventsummer-2020/tree/master/covidsim)

--- a/_posts/2021-02-06-nsa_codebreaker_2020_task6.md
+++ b/_posts/2021-02-06-nsa_codebreaker_2020_task6.md
@@ -364,7 +364,7 @@ Ammar Ratnani
 
 
 
-[1]: <https://github.com/ammrat13/ammrat13.github.io/tree/main/assets/2021/02/06> "My GitHub"
+[1]: <https://github.com/ammrat13/ammrat13.github.io/tree/main/assets/2021/02/06> "Code for this post"
 [2]: <https://en.wikipedia.org/wiki/Half-precision_floating-point_format> "Half-precision Floating-point Format"
 [3]: <https://bugs.python.org/issue11734> "Python Supports 16-Bit Floats"
 [4]: <https://youtu.be/X8jsijhllIA> "Hamming Codes and Error Correction"


### PR DESCRIPTION
I moved a lot of my old repositories to GitLab, so some of the links broke. I also took this opportunity to clean up some unnecessary links.