### PR TITLE
Fix: Add 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,1 @@
+Not Found


### PR DESCRIPTION
Otherwise, Cloudflare pages assumes we're an SPA, and handles requests for pages that don't exist.