### PR TITLE
Fixup: Add `robots.txt` back in

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,9 @@
+# The post listing should not be indexed. Only the home page and each post
+# should be.
+User-agent: *
+Disallow: /post_listing/
+
+# We want to allow all AI use of this site.
+User-Agent: *
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+Allow: /


### PR DESCRIPTION
It turns out, we still want to block some parts of the site for search engines. It's also easier to configure the content signals here.